### PR TITLE
[FIX] account: allow interbranch moves by removing company validation

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -5187,14 +5187,6 @@ class AccountMove(models.Model):
             if move.journal_id.autocheck_on_post:
                 move.checked = move.journal_id.autocheck_on_post
 
-            move_company_and_parents = move.company_id.sudo().parent_ids
-            mismatched_accounts = move.line_ids.mapped('account_id').filtered(lambda account: not move_company_and_parents & account.sudo().company_ids)
-            if mismatched_accounts:
-                validation_msgs.add(self.env._(
-                    "The entry is using accounts (%(accounts_codes_names)s) from a different company.",
-                    accounts_codes_names=format_list(self.env, mismatched_accounts.mapped('display_name'))
-                ))
-
         if validation_msgs:
             msg = "\n".join([line for line in validation_msgs])
             raise UserError(msg)


### PR DESCRIPTION
Odoo 18 added a strict validation in `account.move._post` that ensures all accounts used in move lines belong to the move's company or its parents.

This validation is incompatible with interbranch moves where a single entry can contain lines from different companies.

Changes:
- Removed the check that filters mismatched_accounts based on move.company_id.sudo().parent_ids to restore business flexibility for interbranch operations.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
